### PR TITLE
To Make Calibration workflow of HMS Hodoscope same as SHMS Hodoscope

### DIFF
--- a/CALIBRATION/hms_hodo_calib/README.md
+++ b/CALIBRATION/hms_hodo_calib/README.md
@@ -17,7 +17,7 @@ The two codes have different parameters and it is possible to switch between the
 (In case you are calibrating HMS hodo using a coincidence run, then make sure to include T.coin.*)
 
 
-2. Determine the time walk correction parameters. Instead of "root -l", use "hcana -l".
+2. Determine the time walk correction parameters. Instead of "root -l", I recommend using "hcana -l".
 
      a. Start "root -l" and then  .x timeWalkHistos.C+("current_dir/to/ROOT_filename.root", Run_Number, "hms") ---> If doing coincidence, then "hms"->"coin"
 
@@ -41,5 +41,5 @@ The two codes have different parameters and it is possible to switch between the
 
      c.  It also creates the root file HodoCalibPlots_runnumber.root
 
-     d.  To analyze cosmic data :  .x  fitHodoCalib.C+("current_dir/to/ROOT_filename.root",Run_Number,kTRUE) 
+     d.  To analyze cosmic data :  .x  fitHodoCalib.C+("current_dir/to/ROOT_filename.root",Run_Number,kTRUE)
      e. For cosmic data the speed of light is set to -30 cm/ns and the PID cut is just on P.hod.betanotrack with the default of betanotrack_low_cut = -1.2 and betanotrack_hi_cut = -.7

--- a/CALIBRATION/hms_hodo_calib/timeWalkCalib.C
+++ b/CALIBRATION/hms_hodo_calib/timeWalkCalib.C
@@ -25,14 +25,11 @@
 #include <TF1.h>
 
 
-//============Modified by rparvez: Begin===========//
-// Declare ROOT files
-//TFile *histoFile, *outFile;
+//============Modified by rparvez: Begin============//
 // Declare ROOT files
 TFile *histoFile; 
 TFile *histOutFile;
-//=============Modified by rparvez: End========//
-
+//============Modified by rparvez: End============//
 
 
 
@@ -268,7 +265,7 @@ void drawParams(UInt_t iplane) {
 
 
 
-//==================Modified by rparvez: Begin===============//
+//============Modified by rparvez: Begin============//
 
 //Add method for writing summary plots to ROOT File
 void writePlots(int runNUM) 
@@ -320,7 +317,7 @@ void writePlots(int runNUM)
   return;
 }
 
-//===================Modified by rparvez: End===================//
+//============Modified by rparvez: End============//
 
 
 
@@ -423,7 +420,7 @@ void WriteFitParam(int runNUM)
 
 
 
-//===============Modified by rparvez: Begin==============//
+//============Modified by rparvez: Begin============//
 
 // This is to write all the parrameters with there errors, so that they may be checked against other Runs - NH 21/05/06
 void WriteFitParamErr(int runNUM)
@@ -493,7 +490,7 @@ void WriteFitParamErr(int runNUM)
 
 } //WriteFitParamErr
 
-//===============Modified by rparvez: End===========//
+//============Modified by rparvez: End============//
 
 
 
@@ -569,7 +566,7 @@ using namespace std;
 
 
 
-  //==================Modified by rparvez: Begin===================//
+  //============Modified by rparvez: Begin============//
 
   //histoFile->Close();
 
@@ -591,7 +588,7 @@ using namespace std;
 
   return;
 
-  //================Modified by rparvez: End==============//
+  //============Modified by rparvez: End============//
 
 }
 

--- a/CALIBRATION/hms_hodo_calib/timeWalkHistos.C
+++ b/CALIBRATION/hms_hodo_calib/timeWalkHistos.C
@@ -219,10 +219,10 @@ void timeWalkHistos(TString inputname,Int_t runNum, string SPEC_flg) {    //SPEC
   // replayFile = new TFile(Form("ROOTfiles/hms_coin_replay_production_%d_-1.root", runNum), "READ");
 
 
-  //========================================================//made changes here: start
+  //============Modified by rparvez: Begin============//
   //outFile    = new TFile("timeWalkHistos.root", "RECREATE");
   outFile = new TFile(Form("timeWalkHistos_%d.root", runNum), "RECREATE");
-  //========================================================//made changes here: stop
+  //============Modified by rparvez: End============//
 
 
   // Obtain the tree

--- a/CALIBRATION/shms_hodo_calib/README.md
+++ b/CALIBRATION/shms_hodo_calib/README.md
@@ -16,7 +16,7 @@ The two codes have different parameters and it is possible to switch between the
 
 (In case you are calibrating SHMS hodo using a coincidence run, then make sure to include T.coin.*)
 
-2. Determine the time walk correction parameters. Instead of "root -l", use "hcana -l".
+2. Determine the time walk correction parameters. Instead of "root -l", I recommend using "hcana -l".
 
      a. Start "root -l" and then  .x timeWalkHistos.C+("current_dir/to/ROOT_filename.root",Run_Number, "shms") ---> If doing coincidence, then "shms"->"coin"
 


### PR DESCRIPTION
There's some difference in the hodoscope calibration workflow of SHMS and HMS. Mainly, SHMS hodoscope timeWalkCalib.C works in batch mode (efficient) whereas HMS works in interactive mode (not efficient). Therefore, in order to make HMS Hodoscope calibration same as SHMS, I made changes to 4 files:
1. hms_hodo_calib/README.md
    a. ptofusinginvadc -> htofusinginvadc
    b. timeWalkHistos.root -> timeWalkHistos_runnumber.root
    c. .x timeWalkCalib.C+ -> .x timeWalkCalib.C(runnumber)
    d. add comments on what will happen if you run the code

2. hms_hodo_calib/timeWalkCalib.C
    a. *outFile -> *histOutFile (to make same variable name convention as SHMS without any conflict)
    b. added writePlots(int runNUM) function to create the plots in interactive mode and keep them in Calibration_Plots >> TWpng
    c. added WriteFitParamErr(int runNUM) function write the error in parameter value, same as SHMS case.
    d. timeWalkHistos.root -> timeWalkHistos_%d.root (necessary formatting to show runnumber in filename)
    e. added lines to call these functions correctly

3. hms_hodo_calib/timeWalkHistos.C
    a. timeWalkHistos.root -> timeWalkHistos_%d.root

4. shms_hodo_calib/README.md
    a. timeWalkHistos.root -> timeWalkHistos_runnumber.root
    b. .x timeWalkCalib.C+ -> .x timeWalkCalib.C(runnumber)
    c. made minor formatting change