### PR TITLE
Modified initial hcal, pcal calibrations for phase II

### DIFF
--- a/DBASE/COIN/standard.database
+++ b/DBASE/COIN/standard.database
@@ -160,7 +160,7 @@ g_ctp_hcal_calib_filename = "PARAM/HMS/CAL/hcal_calib_1p531gev_29p045deg_rsidis.
 24875-25483
 g_ctp_hcal_calib_filename = "PARAM/HMS/CAL/hcal_calib_3p642gev_16p750deg_rsidis.param"
 
-25484-25604
+25484-25603
 g_ctp_hcal_calib_filename = "PARAM/HMS/CAL/hcal_calib_3p642gev_16p755deg_rsidis.param"
 
 
@@ -169,11 +169,11 @@ g_ctp_hcal_calib_filename = "PARAM/HMS/CAL/hcal_calib_3p642gev_16p755deg_rsidis.
 # Beginning of R-SIDIS-II (Summer 2026)
 # ----- ****************** --------
 # ----- ****************** --------
-20000-99999
+25604-99999
 g_ctp_parm_filename       = "DBASE/COIN/general_rsidis_phaseII.param"
 g_ctp_kinematics_filename = "DBASE/COIN/standard.kinematics"
 g_ctp_map_filename        = "MAPS/COIN/DETEC/coin.map"
 g_ctp_trigdet_filename    = "PARAM/TRIG/tcoin.param"
 
-g_ctp_pcal_calib_filename = "PARAM/SHMS/CAL/pcal_calib_2p000gev_18p500deg_rsidis.param"
-g_ctp_hcal_calib_filename = "PARAM/HMS/CAL/hcal_calib_3p642gev_16p755deg_rsidis.param"
+g_ctp_pcal_calib_filename = "PARAM/SHMS/CAL/pcal_calib_5p670gev_19p340deg_rsidis.param"
+g_ctp_hcal_calib_filename = "PARAM/HMS/CAL/hcal_calib_1p531gev_29p045deg_rsidis.param"


### PR DESCRIPTION
Based on the nominal HMS, SHMS momentum settings, I've modified the initial hcal, pcal parameters to be used at the start of phase II.  I also modified the run numbers to match with the phase I list, i.e. phase I run numbers end now lead right into phase II run numbers start.